### PR TITLE
Use standard Ingress for Foretold service

### DIFF
--- a/fleet/services/foretold/deployment.yaml
+++ b/fleet/services/foretold/deployment.yaml
@@ -16,20 +16,23 @@ kind: Ingress
 metadata:
   name: foretold-service-ingress
   namespace: weapps
-  annotations: 
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - match: Host(`foretold.mynetapp.site`)
-      kind: Rule
-      services:
-        - name: nginx-service
-          port: 80      
+  ingressClassName: traefik
+  rules:
+  - host: foretold.mynetapp.site
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: foretold-service
+            port:
+              number: 80
   tls:
-    secretName: mynetapp-site-production-tls          
+  - hosts:
+    - foretold.mynetapp.site
+    secretName: mynetapp-site-production-tls
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary
- replace custom Traefik Ingress block with standard Kubernetes Ingress and Traefik ingressClassName

## Testing
- `kubectl apply --dry-run=client -f fleet/services/foretold/deployment.yaml` *(fails: kubectl not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93027e60c8330b8b34d9c38a49ada