### PR TITLE
Use traefik.io API group for Traefik middleware

### DIFF
--- a/fleet/base/fleet.yaml
+++ b/fleet/base/fleet.yaml
@@ -51,7 +51,7 @@ targetCustomizations:
               
       - name: traefik-middleware-ownership
         kind: Middleware
-        apiVersion: traefik.containo.us/v1alpha1
+        apiVersion: traefik.io/v1alpha1
         name: default-headers
         namespace: weapps
         force: true

--- a/fleet/services/traefik-config/middlewares.yaml
+++ b/fleet/services/traefik-config/middlewares.yaml
@@ -1,5 +1,5 @@
 # Default security headers middleware
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: default-headers


### PR DESCRIPTION
## Summary
- update Traefik middleware manifests to use apiVersion traefik.io/v1alpha1

## Testing
- `kubectl apply -f fleet/services/traefik-config/middlewares.yaml` *(fails: command not found)*
- `kubectl get crds | grep traefik` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b932bda4d883308e9756135a7fa2dc